### PR TITLE
Supports profiling in debug mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,10 @@ linters-settings:
     # minimal code complexity to report, 30 by default
     min-complexity: 15
   gosec:
+    # To specify a set of rules to explicitly exclude.
+    # Available rules: https://github.com/securego/gosec#available-rules
+    excludes:
+      - G108
     # To specify the configuration of rules.
     # The configuration of rules is not fully documented by gosec:
     # https://github.com/securego/gosec#configuration

--- a/Makefile
+++ b/Makefile
@@ -142,11 +142,11 @@ test-cover: ## Collect code coverage
 
 bench: ## Benchmark test
 	@echo "-> Running benchmark"
-	@go test -v -bench .
+	@go test -v -bench ./...
 
 profile: ## Test and profile
 	@echo "-> Running profile"
-	@go test -cpuprofile cpu.prof -memprofile mem.prof -v -bench .
+	@go test -cpuprofile cpu.prof -memprofile mem.prof -v -bench ./...
 
 docker-image: ## Build Docker image
 	@echo "-> Building docker image..."

--- a/cmd/wayback/main.go
+++ b/cmd/wayback/main.go
@@ -177,6 +177,7 @@ func handle(cmd *cobra.Command, args []string) {
 
 	logger.SetLogLevel(config.Opts.LogLevel())
 	if debug || config.Opts.HasDebugMode() {
+		profiling()
 		logger.EnableDebug()
 	}
 

--- a/cmd/wayback/pprof.go
+++ b/cmd/wayback/pprof.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/wabarc/logger"
+
+	_ "net/http/pprof"
+)
+
+func profiling() {
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		logger.Fatal("Net listen err: %v", err)
+	}
+
+	addr := listener.Addr().(*net.TCPAddr)
+	logger.Info("Go profiling via: http://%s", addr)
+	logger.Info("More defails can be found at https://go.dev/blog/pprof")
+
+	go func() {
+		log.Println(http.Serve(listener, nil))
+	}()
+}

--- a/service/httpd/httpd.go
+++ b/service/httpd/httpd.go
@@ -59,16 +59,23 @@ func (web *web) handle(pool pooling.Pool) http.Handler {
 			web.process(w, r)
 		})
 	}).Methods(http.MethodPost)
+
 	web.router.HandleFunc("/playback", web.playback).Methods(http.MethodPost)
 
 	web.router.HandleFunc("/healthcheck", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("ok"))
 	}).Name("healthcheck")
+
 	web.router.HandleFunc("/version", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(version.Version))
 	}).Name("version")
+
 	if config.Opts.EnabledMetrics() {
 		web.router.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
+	}
+
+	if config.Opts.HasDebugMode() {
+		web.router.PathPrefix("/debug/").Handler(http.DefaultServeMux)
 	}
 
 	web.router.HandleFunc("/robots.txt", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Enabling debug mode is required for profiling. There are two ways to use the `go tool pprof`:

- random port entry `localhost:{random port}`
- web entry `localhost:8964`

>
> Use the pprof tool to look at the heap profile:
>
> ```shell
> go tool pprof http://localhost:8964/debug/pprof/heap
> ```
> 
> Or to look at a 30-second CPU profile:
> 
> ```shell
> go tool pprof http://localhost:8964/debug/pprof/profile?seconds=30
> ```
> 
> Or to look at the goroutine blocking profile, after calling runtime.SetBlockProfileRate in your program:
> 
> ```shell
> go tool pprof http://localhost:8964/debug/pprof/block
> ```
> 
> Or to look at the holders of contended mutexes, after calling runtime.SetMutexProfileFraction in your program:
> 
> ```shell
> go tool pprof http://localhost:8964/debug/pprof/mutex
> ```
> 
> The package also exports a handler that serves execution trace data for the "go tool trace" command. To collect a 5-> second execution trace:
> 
> ```shell
> wget -O trace.out http://localhost:8964/debug/pprof/trace?seconds=5
> go tool trace trace.out
> ```
> 
> To view all available profiles, open http://localhost:8964/debug/pprof/ in your browser.

Ref: <https://pkg.go.dev/net/http/pprof>
