### PR TITLE
Fix install command to use "go install"

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The simplest, cross-platform way is to download from [GitHub Releases](https://g
 From source:
 
 ```sh
-go get -u github.com/wabarc/wayback/cmd/wayback
+go install github.com/wabarc/wayback/cmd/wayback@latest
 ```
 
 From GitHub Releases:


### PR DESCRIPTION
Using the `go get` command no longer works in Go 1.19.

```
Bash > go get -u github.com/wabarc/wayback/cmd/wayback

go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```