### PR TITLE
summary: add Requesty as an LLM provider

### DIFF
--- a/docs/environment.md
+++ b/docs/environment.md
@@ -102,10 +102,10 @@ Use the `-c` / `--config` option to specify the build definition file to use.
 | -                   | `WAYBACK_ONION_LOCAL_PORT`        | `8964`                     | Local port for Tor Hidden Service, also support for a **reverse proxy**. This is ignored if `WAYBACK_LISTEN_ADDR` is set. |
 | -                   | `WAYBACK_ONION_REMOTE_PORTS`      | `80`                       | Remote ports for Tor Hidden Service, e.g. `WAYBACK_ONION_REMOTE_PORTS=80,81` |
 | -                   | `WAYBACK_ONION_DISABLED`          | `false`                    | Disable onion service                                        |
-| -                   | `WAYBACK_LLM_PROVIDER`            | ``                         | Enables AI-enhanced summary, supported: `cohere`, `openrouter` |
+| -                   | `WAYBACK_LLM_PROVIDER`            | ``                         | Enables AI-enhanced summary, supported: `cohere`, `openrouter`, `requesty` |
 | -                   | `WAYBACK_LLM_BASE_URL`            | ``                         | LLM API base URL                                             |
 | -                   | `WAYBACK_LLM_APIKEY`              | ``                         | LLM API key                                                  |
-| -                   | `WAYBACK_LLM_MODEL`               | ``                         | LLM model. Each provider has a sensible default: cohere: command-a-03-2025 \| openrouter: openrouter/auto. |
+| -                   | `WAYBACK_LLM_MODEL`               | ``                         | LLM model. Each provider has a sensible default: cohere: command-a-03-2025 \| openrouter: openrouter/auto \| requesty: openai/gpt-4o-mini. |
 | -                   | `WAYBACK_SLOT`                    | -                          | Pinning service for IPFS mode of pinner, see [ipfs-pinner](https://github.com/wabarc/ipfs-pinner#supported-pinning-services) |
 | -                   | `WAYBACK_APIKEY`                  | -                          | API key for pinning service                                  |
 | -                   | `WAYBACK_SECRET`                  | -                          | API secret for pinning service                               |

--- a/summary/requesty.go
+++ b/summary/requesty.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Wayback Archiver. All rights reserved.
+// Use of this source code is governed by the GNU GPL v3
+// license that can be found in the LICENSE file.
+
+package summary // import "github.com/wabarc/wayback/summary"
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/wabarc/wayback/config"
+	"github.com/wabarc/wayback/ingress"
+)
+
+// Interface guard
+var _ Summarizer = (*Requesty)(nil)
+
+// Requesty represents a text summarization client for Requesty LLM service.
+type Requesty struct {
+	client *http.Client
+	apiKey string
+	model  string
+}
+
+// NewRequesty creates a `Requesty` instance with the specified `http.Client` and options.
+// If the `http.Client` instance is `nil`, the default client is used. This function returns a pointer
+// to the newly created `Requesty` instance and an error, if any.
+func NewRequesty(c *http.Client, opts *config.Options) *Requesty {
+	if c == nil {
+		c = ingress.Client()
+	}
+	model := opts.LLMModel()
+	if model == "" {
+		model = "openai/gpt-4o-mini"
+	}
+
+	return &Requesty{
+		client: c,
+		apiKey: opts.LLMApiKey(),
+		model:  model,
+	}
+}
+
+// Summarize generates a summary of the input text using Requesty's AI models.
+// Returns the generated summary as a string and an error, if any.
+func (rq *Requesty) Summarize(s string) (string, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("text not found")
+	}
+
+	body := chatRequest{
+		Model: rq.model,
+		Messages: []chatMessage{
+			{Role: "system", Content: systemPrompt},
+			{Role: "user", Content: s},
+		},
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal json: %v", err)
+	}
+
+	endpoint := "https://router.requesty.ai/v1/chat/completions"
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewReader(buf))
+	if err != nil {
+		return "", fmt.Errorf("failed to make request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+rq.apiKey)
+
+	res, err := rq.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return "", fmt.Errorf("requesty api error: status %d", res.StatusCode)
+	}
+
+	var cr chatResponse
+	if err := json.NewDecoder(res.Body).Decode(&cr); err != nil {
+		return "", fmt.Errorf("failed to decode body: %v", err)
+	}
+
+	if len(cr.Choices) > 0 && strings.TrimSpace(cr.Choices[0].Message.Content) != "" {
+		return strings.TrimSpace(cr.Choices[0].Message.Content), nil
+	}
+
+	return s, nil
+}

--- a/summary/requesty_test.go
+++ b/summary/requesty_test.go
@@ -1,0 +1,183 @@
+// Copyright 2026 Wayback Archiver. All rights reserved.
+// Use of this source code is governed by the GNU GPL v3
+// license that can be found in the LICENSE file.
+
+package summary // import "github.com/wabarc/wayback/summary"
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/wabarc/helper"
+	"github.com/wabarc/wayback/config"
+)
+
+func TestNewRequesty(t *testing.T) {
+	httpClient, mux, server := helper.MockServer()
+	defer server.Close()
+
+	handleFunc := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/chat/completions":
+			w.Write(summarizeResponse)
+		}
+	}
+	mux.HandleFunc("/", handleFunc)
+
+	tests := []struct {
+		desc      string
+		client    *http.Client
+		key       string
+		expectErr bool
+		expectNil bool
+	}{
+		{
+			desc:      "Valid inputs",
+			client:    httpClient,
+			key:       "valid_api_key",
+			expectErr: false,
+			expectNil: false,
+		},
+		{
+			desc:      "Invalid API key",
+			client:    httpClient,
+			key:       apiKey,
+			expectErr: true,
+			expectNil: true,
+		},
+		{
+			desc:      "Nil http.Client",
+			client:    nil,
+			key:       apiKey,
+			expectErr: false,
+			expectNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Setenv("WAYBACK_LLM_PROVIDER", "requesty")
+			t.Setenv("WAYBACK_LLM_APIKEY", tt.key)
+
+			parser := config.NewParser()
+			opts, err := parser.ParseEnvironmentVariables()
+			if err != nil {
+				t.Fatalf("Parse environment variables or flags failed, error: %v", err)
+			}
+
+			op := NewRequesty(tt.client, opts)
+			if !tt.expectNil && op == nil {
+				t.Errorf("Unexpected nil value for Requesty instance")
+			}
+		})
+	}
+}
+
+func TestRequestySummarize(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		mockStatus  int
+		mockBody    string
+		expected    string
+		expectedErr string
+	}{
+		{
+			name:        "Empty string",
+			input:       "",
+			expected:    "",
+			expectedErr: "text not found",
+		},
+		{
+			name:       "Valid input",
+			input:      "This is a test input for summarization.",
+			mockStatus: 200,
+			mockBody: `{
+				"messages":[
+					{"role":"user","content":"This is the summary."}
+				]
+			}`,
+			expected:    "This is the summary.",
+			expectedErr: "",
+		},
+		{
+			name:        "API error status",
+			input:       "Non-empty",
+			mockStatus:  500,
+			mockBody:    `{"error":"server"}`,
+			expected:    "",
+			expectedErr: "requesty api error: status 500",
+		},
+	}
+
+	httpClient, mux, server := helper.MockServer()
+	defer server.Close()
+
+	// Register handler at expected endpoint path used by the client.
+	mux.HandleFunc("/v1/chat/completions", func(w http.ResponseWriter, r *http.Request) {
+		// optional: assert method and headers
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// Find matching test case by inspecting body or rely on sequential handling.
+		// For simplicity, read body and decide response based on test inputs:
+		var req struct {
+			Messages []struct {
+				Content string `json:"content"`
+			} `json:"messages"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		r.Body.Close()
+
+		switch {
+		case strings.Contains(req.Messages[1].Content, "This is a test input for summarization."):
+			w.WriteHeader(200)
+			w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"This is the summary."}}]}`))
+		case strings.Contains(req.Messages[1].Content, "Non-empty"):
+			w.WriteHeader(500)
+			w.Write([]byte("server error"))
+		default:
+			// default success
+			w.WriteHeader(200)
+			w.Write([]byte(`{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`))
+		}
+	})
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("WAYBACK_LLM_PROVIDER", "requesty")
+			t.Setenv("WAYBACK_LLM_APIKEY", "test-key")
+
+			parser := config.NewParser()
+			opts, err := parser.ParseEnvironmentVariables()
+			if err != nil {
+				t.Fatalf("Parse environment variables or flags failed, error: %v", err)
+			}
+
+			op := NewRequesty(httpClient, opts)
+
+			actual, actualErr := op.Summarize(tt.input)
+
+			if tt.expectedErr != "" {
+				if actualErr == nil {
+					t.Fatalf("expected error %q, got nil", tt.expectedErr)
+				}
+				if actualErr.Error() != tt.expectedErr {
+					t.Fatalf("unexpected error, got %q expected %q", actualErr.Error(), tt.expectedErr)
+				}
+				return
+			}
+
+			if actualErr != nil {
+				t.Fatalf("unexpected error: %v", actualErr)
+			}
+			if actual != tt.expected {
+				t.Fatalf(`unexpected summary, got "%v" instead of "%v"`, actual, tt.expected)
+			}
+		})
+	}
+}

--- a/summary/summary.go
+++ b/summary/summary.go
@@ -28,6 +28,8 @@ func NewSummary(opts *config.Options) Summarizer {
 		return NewCohere(ingress.Client(), opts)
 	case "openrouter":
 		return NewOpenRouter(ingress.Client(), opts)
+	case "requesty":
+		return NewRequesty(ingress.Client(), opts)
 	case "ollama":
 		return NewOllama(ingress.Client(), opts)
 	}

--- a/wayback.1
+++ b/wayback.1
@@ -225,7 +225,7 @@ Directory to store binary file, e.g. PDF, html file\&.
 Max size to limit download stream media. default 512MB\&.
 .TP
 .B WAYBACK_LLM_PROVIDER
-Enables AI-enhanced summary. Provider options: cohere | openrouter\&.
+Enables AI-enhanced summary. Provider options: cohere | openrouter | requesty\&.
 .TP
 .B WAYBACK_LLM_BASE_URL
 LLM API base URL\&.
@@ -236,7 +236,7 @@ LLM API key\&.
 .B WAYBACK_LLM_MODEL
 LLM model. Each provider has a sensible default:
 .br
-cohere: command-a-03-2025 | openrouter: openrouter/auto\&.
+cohere: command-a-03-2025 | openrouter: openrouter/auto | requesty: openai/gpt-4o-mini\&.
 .TP
 .B WAYBACK_MEDIA_SITES
 Extra media websites wish to be supported, separate with comma\&.


### PR DESCRIPTION
This adds [Requesty](https://requesty.ai) as an LLM summarizer provider, mirroring the existing OpenRouter summarizer.

Requesty (`https://router.requesty.ai/v1`) is an OpenAI-compatible LLM router, so the wiring follows the OpenRouter summarizer closely.

Changes:
- `summary/requesty.go`: new `Requesty` `Summarizer` mirroring `OpenRouter` (endpoint `https://router.requesty.ai/v1/chat/completions`, `Authorization: Bearer` auth, default model `openai/gpt-4o-mini`). The OpenRouter default `openrouter/auto` has no Requesty equivalent, so a concrete default model is used instead.
- `summary/summary.go`: add the `requesty` branch to the provider dispatch.
- `docs/environment.md`, `wayback.1`: document `requesty` alongside the other LLM providers.
- `summary/requesty_test.go`: tests mirroring `openrouter_test.go`.

The LLM options (`WAYBACK_LLM_PROVIDER`/`_APIKEY`/`_MODEL`) are generic, so no new env vars were added — `requesty` is selected by setting the provider string.

Verified: `go build ./...`, `go vet ./summary/ ./config/`, `go test ./summary/` all pass.

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.